### PR TITLE
Add resolving for Mach-O object files

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,11 +1,15 @@
 {
-    "name": "ircmaxell/php-elf-symbolresolver",
-    "description": "A linux object file (ELF) parser",
+    "name": "ircmaxell/php-object-symbolresolver",
+    "description": "An object file (ELF, Mach-O) parser",
     "license": "MIT",
     "authors": [
         {
             "name": "Anthony Ferrara",
             "email": "ircmaxell@gmail.com"
+        },
+        {
+            "name": "Bob Weinand",
+            "email": "bobwei9@hotmail.com"
         }
     ],
     "require": {
@@ -15,7 +19,7 @@
     },
     "autoload": {
         "psr-4": {
-            "PHPELFSymbolResolver\\": "lib/"
+            "PHPObjectSymbolResolver\\": "lib/"
         }
     }
 

--- a/demo.php
+++ b/demo.php
@@ -4,7 +4,7 @@ require __DIR__ . '/vendor/autoload.php';
 
 $file = '/usr/lib/x86_64-linux-gnu/libLLVM-9.so.1';
 
-$parser = new PHPELFSymbolResolver\Parser;
+$parser = \PHPObjectSymbolResolver\Parser::parserFor($file);
 
 $objFile = $parser->parse($file);
 

--- a/lib/ELF/ObjectFile.php
+++ b/lib/ELF/ObjectFile.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace PHPObjectSymbolResolver\ELF;
+
+class ObjectFile implements \PHPObjectSymbolResolver\ObjectFile {
+    const CLASS32 = 1;
+    const CLASS64 = 2;
+    public int $class;
+
+    const BYTEORDER_LSB = 1;
+    const BYTEORDER_MSB = 2;
+    public int $byteOrder;
+
+    public int $version;
+
+    public int $abi;
+
+    public int $abiVersion;
+
+    const TYPE_NONE = 0;
+    const TYPE_RELOCATABLE = 1;
+    const TYPE_EXECUTABLE = 2;
+    const TYPE_SHARD_OBJECT = 3;
+    const TYPE_CORE = 4;
+
+    public int $type;
+    public int $machine;
+    public int $eversion;
+    public int $entry;
+    public int $phoff;
+    public int $shoff;
+    public int $flags;
+    public int $phentsize;
+    public int $phnum;
+    public int $shentsize;
+    public int $shnum;
+    public int $shstrndx;
+
+    public array $sections;
+
+    public function getAllSymbols(): array {
+        $result = [];
+        foreach ($this->sections as $section) {
+            foreach ($section->symbols as $symbol) {
+                if (!$symbol->isOther(Symbol::VISIBILITY_DEFAULT)) {
+                    continue;
+                }
+                if (!$symbol->isGlobal()) {
+                    continue;
+                }
+                $result[] = $symbol->nameString;
+            }
+        }
+        return $result;
+    }
+
+	public function is32Bit(): bool {
+		return $this->class === self::CLASS32;
+	}
+
+	public function is64Bit(): bool {
+		return $this->class === self::CLASS64;
+	}
+
+	public function hasLowestByteFirst(): bool {
+		return $this->byteOrder === self::BYTEORDER_LSB;
+	}
+}

--- a/lib/ELF/Parser.php
+++ b/lib/ELF/Parser.php
@@ -1,0 +1,152 @@
+<?php
+
+namespace PHPObjectSymbolResolver\ELF;
+
+class Parser extends \PHPObjectSymbolResolver\Parser {
+    const HEADER = "\x7fELF";
+
+    public function parse(string $file): ObjectFile {
+        $this->data = file_get_contents($file);
+        if (strlen($this->data) < 16) {
+            throw new \LogicException("File is too short to be an ELF file");
+        }
+        if (substr($this->data, 0, 4) !== self::HEADER) {
+            throw new \LogicException("File is not in ELF format");
+        }
+        $this->obj = new ObjectFile;
+        $this->parseElfHeader();
+        $this->parseElfSections();
+        $this->parseStringSections();
+        $this->parseSymbolTables();
+
+        $this->data = '';
+        return $this->obj;
+    }
+
+    protected function parseElfHeader(): void {
+        $this->obj->class = ord($this->data[4]);
+        $this->obj->byteOrder = ord($this->data[5]);
+        $this->obj->version = ord($this->data[6]);
+        $this->obj->abi = ord($this->data[7]);
+        $this->obj->abiVersion = ord($this->data[8]);
+
+		if ($this->obj->byteOrder !== ObjectFile::BYTEORDER_LSB && $this->obj->byteOrder !== ObjectFile::BYTEORDER_MSB) {
+			throw new \LogicException("Unknown byte ordering {$this->obj->byteOrder}");
+		}
+
+		$offset = 16;
+        $this->obj->type = $this->parseHalf($offset);
+        $this->obj->machine = $this->parseHalf($offset);
+        $this->obj->eversion = $this->parseWord($offset);
+        $this->obj->entry = $this->parseAddr($offset);
+        $this->obj->phoff = $this->parseOff($offset);
+        $this->obj->shoff = $this->parseOff($offset);
+        $this->obj->flags = $this->parseWord($offset);
+        $this->obj->ehsize = $this->parseHalf($offset);
+        $this->obj->phentsize = $this->parseHalf($offset);
+        $this->obj->phnum = $this->parseHalf($offset);
+        $this->obj->shentsize = $this->parseHalf($offset);
+        $this->obj->shnum = $this->parseHalf($offset);
+        $this->obj->shstrndx = $this->parseHalf($offset);
+    }
+
+    protected function parseElfSections(): void {
+        $offset = $this->obj->shoff;
+        $shnum = $this->obj->shnum ?: $this->determineShnum();
+        for ($i = 0; $i < $shnum; $i++) {
+            $this->parseSectionHeader($this->obj->shoff + $i * $this->obj->shentsize);
+        }
+    }
+
+    protected function parseStringSections(): void {
+        $nameSection = $this->obj->sections[$this->obj->shstrndx];
+        foreach ($this->obj->sections as $section) {
+            $section->nameString = $this->readStringSectionOffset($nameSection, $section->name);
+        }
+    }
+
+    protected function parseSymbolTables(): void {
+        foreach ($this->obj->sections as $section) {
+            if ($section->type !== Section::TYPE_SYMTAB && $section->type !== Section::TYPE_DYNSYM) {
+                continue;
+            }
+            $this->parseSymbolTable($section);
+        }
+    }
+
+    protected function parseSymbolTable(Section $section) {
+        $offset = $section->offset;
+        $size = $section->size;
+        $end = $offset + $size;
+        if ($section->type === Section::TYPE_SYMTAB) {
+            $strtab = $this->findSection('.strtab');
+        } else {
+            $strtab = $this->findSection('.dynstr');
+        }
+        while ($offset < $end) {
+            $symbol = $this->parseSymbol($offset);
+            $symbol->nameString = $this->readStringSectionOffset($strtab, $symbol->name);
+            $section->symbols[] = $symbol;
+        }
+
+    }
+
+    protected function findSection(string $name): Section {
+        foreach ($this->obj->sections as $section) {
+            if ($section->nameString === $name) {
+                return $section;
+            }
+        }
+        throw new \LogicException("Could not find section $name");
+    }
+
+    protected function parseSymbol(int &$offset): Symbol {
+        $symbol = new Symbol;
+        if ($this->obj->class === ObjectFile::CLASS32) {
+            $symbol->name = $this->parseWord($offset);
+            $symbol->value = $this->parseAddr($offset);
+            $symbol->size = $this->parseWord($offset);
+            $symbol->info = $this->parseUChar($offset);
+            $symbol->other = $this->parseUChar($offset);
+            $symbol->shndx = $this->parseHalf($offset);
+        } else {
+            $symbol->name = $this->parseWord($offset);
+            $symbol->info = $this->parseUChar($offset);
+            $symbol->other = $this->parseUChar($offset);
+            $symbol->shndx = $this->parseHalf($offset);
+            $symbol->value = $this->parseAddr($offset);
+            $symbol->size = $this->parseXWord($offset);
+        }
+        return $symbol;
+    }
+
+    protected function readStringSectionOffset(Section $section, int $offset): string {
+        $mainOffset = $section->offset;
+        $size = $section->size;
+        $end = $mainOffset + $size;
+        $buffer = '';
+        for ($i = $offset + $mainOffset; $i < $end; $i++) {
+            if ($this->data[$i] === "\0") {
+                return $buffer;
+            } else {
+                $buffer .= $this->data[$i];
+            }
+        }
+        return $buffer;
+    }
+
+    protected function parseSectionHeader(int $offset): void {
+        $section = new Section;
+        $section->name = $this->parseWord($offset);
+        $section->type = $this->parseWord($offset);
+        $section->flags = $this->parseXWord($offset);
+        $section->addr = $this->parseAddr($offset);
+        $section->offset = $this->parseOff($offset);
+        $section->size = $this->parseXWord($offset);
+        $section->link = $this->parseWord($offset);
+        $section->info = $this->parseWord($offset);
+        $section->addralign = $this->parseXWord($offset);
+        $section->entsize = $this->parseXWord($offset);
+        $this->obj->sections[] = $section;
+    }
+}

--- a/lib/ELF/Section.php
+++ b/lib/ELF/Section.php
@@ -1,9 +1,8 @@
 <?php
 
-namespace PHPELFSymbolResolver;
+namespace PHPObjectSymbolResolver\ELF;
 
 class Section {
-
     public int $name;
     public string $nameString;
 
@@ -24,6 +23,7 @@ class Section {
     public int $flags;
     public int $addr;
     public int $offset;
+    public int $size;
     public int $link;
     public int $info;
     public int $addralign;

--- a/lib/ELF/Symbol.php
+++ b/lib/ELF/Symbol.php
@@ -1,0 +1,34 @@
+<?php
+
+namespace PHPObjectSymbolResolver\ELF;
+
+class Symbol implements \PHPObjectSymbolResolver\Symbol {
+    const VISIBILITY_DEFAULT = 0;
+    const VISIBILITY_INTERNAL = 1;
+    const VISIBILITY_HIDDEN = 2;
+    const VISIBILITY_PROTECTED = 3;
+
+    const BINDING_LOCAL = 0;
+    const BINDING_GLOBAL = 1;
+    const BINDING_WEAK = 2;
+
+    public int $name;
+    public string $nameString;
+    public int $value;
+    public int $size;
+    public int $info;
+    public int $other;
+    public int $shndx;
+
+    public function isLocal(): bool {
+        return ($this->info >> 4) === self::BINDING_LOCAL;
+    }
+
+    public function isGlobal(): bool {
+        return ($this->info >> 4) === self::BINDING_GLOBAL;
+    }
+
+    public function isWeak(): bool {
+        return ($this->info >> 4) === self::BINDING_WEAK;
+    }
+}

--- a/lib/MachO/Command.php
+++ b/lib/MachO/Command.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace PHPObjectSymbolResolver\MachO;
+
+class Command {
+    public int $cmd;
+    public int $offset;
+
+	const LC_REQ_DYLD = 0x80000000;
+
+	const LC_SEGMENT = 0x1; // segment of this file to be mapped
+	const LC_SYMTAB = 0x2; // link-edit stab symbol table info
+	const LC_SYMSEG = 0x3; // link-edit gdb symbol table info (obsolete)
+	const LC_THREAD = 0x4; // thread
+	const LC_UNIXTHREAD = 0x5; // unix thread (includes a stack)
+	const LC_LOADFVMLIB = 0x6; // load a specified fixed VM shared library
+	const LC_IDFVMLIB = 0x7; // fixed VM shared library identification
+	const LC_IDENT = 0x8; // object identification info (obsolete)
+	const LC_FVMFILE = 0x9; // fixed VM file inclusion (internal use)
+	const LC_PREPAGE = 0xa; // prepage command (internal use)
+	const LC_DYSYMTAB = 0xb; // dynamic link-edit symbol table info
+	const LC_LOAD_DYLIB = 0xc; // load a dynamically linked shared library
+	const LC_ID_DYLIB = 0xd; // dynamically linked shared lib ident
+	const LC_LOAD_DYLINKER = 0xe; // load a dynamic linker
+	const LC_ID_DYLINKER = 0xf; // dynamic linker identification
+	const LC_PREBOUND_DYLIB = 0x10; // modules prebound for a dynamically
+	const LC_ROUTINES = 0x11; // image routines
+	const LC_SUB_FRAMEWORK = 0x12; // sub framework
+	const LC_SUB_UMBRELLA = 0x13; // sub umbrella
+	const LC_SUB_CLIENT = 0x14; // sub client
+	const LC_SUB_LIBRARY = 0x15; // sub library
+	const LC_TWOLEVEL_HINTS = 0x16; // two-level namespace lookup hints
+	const LC_PREBIND_CKSUM = 0x17; // prebind checksum
+	const LC_LOAD_WEAK_DYLIB = (0x18 | self::LC_REQ_DYLD); // load a dynamically linked shared library that is allowed to be missing (all symbols are weak imported).
+	const LC_SEGMENT_64 = 0x19; // 64-bit segment of this file to be mapped
+	const LC_ROUTINES_64 = 0x1a; // 64-bit image routines
+	const LC_UUID = 0x1b; // the uuid
+	const LC_RPATH = (0x1c | self::LC_REQ_DYLD); // runpath additions
+	const LC_CODE_SIGNATURE = 0x1d; // local of code signature
+	const LC_SEGMENT_SPLIT_INFO = 0x1e; // local of info to split segments
+	const LC_REEXPORT_DYLIB = (0x1f | self::LC_REQ_DYLD); // load and re-export dylib
+	const LC_LAZY_LOAD_DYLIB = 0x20; // delay load of dylib until first use
+	const LC_ENCRYPTION_INFO = 0x21; // encrypted segment information
+	const LC_DYLD_INFO = 0x22; // compressed dyld information
+	const LC_DYLD_INFO_ONLY = (0x22 | self::LC_REQ_DYLD); // compressed dyld information only
+	const LC_LOAD_UPWARD_DYLIB = (0x23 | self::LC_REQ_DYLD); // load upward dylib
+	const LC_VERSION_MIN_MACOSX = 0x24; // build for MacOSX min OS version
+	const LC_VERSION_MIN_IPHONEOS = 0x25; // build for iPhoneOS min OS version
+	const LC_FUNCTION_STARTS = 0x26; // compressed table of function start addresses
+	const LC_DYLD_ENVIRONMENT = 0x27; // string for dyld to treat like environment variable
+	const LC_MAIN = (0x28|self::LC_REQ_DYLD); // replacement for LC_UNIXTHREAD
+	const LC_DATA_IN_CODE = 0x29; // table of non-instructions in __text
+	const LC_SOURCE_VERSION = 0x2A; // source version used to build binary
+	const LC_DYLIB_CODE_SIGN_DRS = 0x2B; // Code signing DRs copied from linked dylibs
+	const LC_ENCRYPTION_INFO_64 = 0x2C; // 64-bit encrypted segment information
+	const LC_LINKER_OPTION = 0x2D; // linker options in MH_OBJECT files
+	const LC_LINKER_OPTIMIZATION_HINT = 0x2E; // optimization hints in MH_OBJECT files
+	const LC_VERSION_MIN_TVOS = 0x2F; // build for AppleTV min OS version
+	const LC_VERSION_MIN_WATCHOS = 0x30; // build for Watch min OS version
+	const LC_NOTE = 0x31; // arbitrary data included within a Mach-O file
+	const LC_BUILD_VERSION = 0x32; // build for platform min OS version
+	const LC_DYLD_EXPORTS_TRIE = (0x33 | self::LC_REQ_DYLD); // used with linkedit_data_command, payload is trie
+	const LC_DYLD_CHAINED_FIXUPS = (0x34 | self::LC_REQ_DYLD); // used with linkedit_data_command
+
+	public $parsed;
+}

--- a/lib/MachO/ObjectFile.php
+++ b/lib/MachO/ObjectFile.php
@@ -1,0 +1,61 @@
+<?php
+
+namespace PHPObjectSymbolResolver\MachO;
+
+class ObjectFile implements \PHPObjectSymbolResolver\ObjectFile {
+    const CLASS32 = 1;
+    const CLASS64 = 2;
+    public int $class;
+    public bool $isLSB;
+
+    const MH_OBJECT = 1;
+    const MH_EXECUTE = 2;
+    const MH_FVMLIB = 3;
+    const MH_CORE = 4;
+    const MH_PRELOAD = 5;
+    const MH_DYLIB = 6;
+    const MH_DYLINKER = 7;
+    const MH_BUNDLE = 8;
+    const MH_DYLIB_STUB = 9;
+    const MH_DYSM = 10;
+    const MH_KEXT_BUNDLE = 11;
+
+    public int $cpuType;
+    public int $cpuSubtype;
+    public int $fileType;
+    public int $numOfCmds;
+    public int $sizeOfCmds;
+    public int $flags;
+    public int $reserved;
+
+	/** @var Command[] */
+    public array $commands = [];
+	public array $segments = [];
+
+    public function getAllSymbols(): array {
+        $result = [];
+        foreach ($this->commands as $command) {
+			if ($command->parsed instanceof SymtabCommand) {
+				foreach ($command->parsed->symbols as $symbol) {
+					if (!$symbol->isGlobal()) {
+						continue;
+					}
+					$result[] = $symbol->name;
+				}
+			}
+        }
+        return $result;
+    }
+
+	public function is32Bit(): bool {
+		return $this->class === self::CLASS32;
+	}
+
+	public function is64Bit(): bool {
+		return $this->class === self::CLASS64;
+	}
+
+	public function hasLowestByteFirst(): bool {
+		return $this->isLSB;
+	}
+}

--- a/lib/MachO/Parser.php
+++ b/lib/MachO/Parser.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace PHPObjectSymbolResolver\MachO;
+
+class Parser extends \PHPObjectSymbolResolver\Parser {
+	const HEADER_32 = "\xce\xfa\xed\xfe";
+	const HEADER_64 = "\xcf\xfa\xed\xfe";
+
+	public static function isValidMagic($magic) {
+		return $magic === self::HEADER_32 || $magic === self::HEADER_64 || $magic === strrev(self::HEADER_32) || $magic === strrev(self::HEADER_64);
+	}
+
+	public function parse(string $file): ObjectFile {
+		$this->data = file_get_contents($file);
+		if (strlen($this->data) < 16) {
+			throw new \LogicException("File is too short to be an ELF file");
+		}
+		$this->obj = new ObjectFile;
+		$offset = $this->parseMachOHeader();
+		for ($i = 0; $i < $this->obj->numOfCmds; ++$i) {
+			$this->obj->commands[] = $this->parseCommand($offset);
+		}
+		foreach ($this->obj->commands as $command) {
+			$this->evaluateCommand($command);
+		}
+
+		$this->data = '';
+		return $this->obj;
+	}
+
+	protected function parseMachOHeader() {
+		$magic = substr($this->data, 0, 4);
+		if (!self::isValidMagic($magic)) {
+			throw new \LogicException("File is not in Mach-O format");
+		}
+		$this->obj->isLSB = $magic[1] === "\xfa";
+		$this->obj->class = $magic === self::HEADER_64 || $magic === strrev(self::HEADER_64) ? ObjectFile::CLASS64 : ObjectFile::CLASS32;
+
+		$offset = 4;
+		$this->obj->cpuType = $this->parseWord($offset);
+		$this->obj->cpuSubtype = $this->parseWord($offset);
+		$this->obj->fileType = $this->parseWord($offset);
+		$this->obj->numOfCmds = $this->parseWord($offset);
+		$this->obj->sizeOfCmds = $this->parseWord($offset);
+		$this->obj->flags = $this->parseWord($offset);
+
+		if ($this->obj->is64Bit()) {
+			$this->obj->reserved = $this->parseWord($offset);
+		}
+
+		return $offset;
+	}
+
+	protected function parseCommand(int &$offset) {
+		$cmd = new Command;
+		$cmd->cmd = $this->parseWord($offset);
+		$size = $this->parseWord($offset);
+		$cmd->offset = $offset;
+		$offset += $size - 8;
+		return $cmd;
+	}
+
+	protected function evaluateCommand(Command $command) {
+		switch ($command->cmd) {
+			case Command::LC_SYMTAB:
+				$symtab = new SymtabCommand;
+				$command->parsed = $symtab;
+
+				$offset = $command->offset;
+				$symtab->symOff = $this->parseWord($offset);
+				$symtab->nSyms = $this->parseWord($offset);
+				$symtab->strOff = $this->parseWord($offset);
+				$symtab->strSize = $this->parseWord($offset);
+
+				$offset = $symtab->symOff;
+				for ($i = 0; $i < $symtab->nSyms; ++$i) {
+					$symbol = new Symbol;
+					$symtab->symbols[] = $symbol;
+					$symbol->nStrx = $this->parseWord($offset);
+					$symbol->nType = $this->parseUChar($offset);
+					$symbol->nSect = $this->parseUChar($offset);
+					$symbol->nDesc = $this->parseHalf($offset);
+					$symbol->nValue = $this->parseXWord($offset);
+
+					if ($symbol->nStrx) {
+						$nameOffset = $symtab->strOff + $symbol->nStrx;
+						$nameDelimiter = strpos($this->data, "\0", $nameOffset);
+						$symbol->name = substr($this->data, $nameOffset, $nameDelimiter - $nameOffset);
+					} else {
+						$symbol->name = "";
+					}
+				}
+				break;
+
+			case Command::LC_SEGMENT:
+			case Command::LC_SEGMENT_64:
+				$offset = $command->offset;
+				$segment = new Segment;
+				$command->parsed = $segment;
+				$this->obj->segments[] = $segment;
+				$segment->name = $this->parseNullTerminatedString(16, $offset);
+				$segment->vmaddr = $this->parseXWord($offset);
+				$segment->vmsize = $this->parseXWord($offset);
+				$segment->fileoff = $this->parseXWord($offset);
+				$segment->filesize = $this->parseXWord($offset);
+				$segment->maxprot = $this->parseWord($offset);
+				$segment->initprot = $this->parseWord($offset);
+				$segment->nSects = $this->parseWord($offset);
+				$segment->flags = $this->parseWord($offset);
+
+				for ($i = 0; $i < $segment->nSects; ++$i) {
+					$section = new Section;
+					$segment->sections[] = $section;
+					$section->name = $this->parseNullTerminatedString(16, $offset);
+					$section->segname = $this->parseNullTerminatedString(16, $offset);
+					$section->addr = $this->parseXWord($offset);
+					$section->size = $this->parseXWord($offset);
+					$section->offset = $this->parseWord($offset);
+					$section->align = $this->parseWord($offset);
+					$section->reloff = $this->parseWord($offset);
+					$section->nreloc = $this->parseWord($offset);
+					$section->flags = $this->parseWord($offset);
+					$section->reserved1 = $this->parseWord($offset);
+					$section->reserved2 = $this->parseWord($offset);
+				}
+				break;
+		}
+	}
+}

--- a/lib/MachO/Section.php
+++ b/lib/MachO/Section.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PHPObjectSymbolResolver\MachO;
+
+class Section {
+    public string $name;
+    public string $segname;
+
+    public int $addr;
+    public int $size;
+    public int $offset;
+    public int $align;
+    public int $reloff;
+    public int $nreloc;
+    public int $flags;
+    public int $reserved1;
+    public int $reserved2;
+}

--- a/lib/MachO/Segment.php
+++ b/lib/MachO/Segment.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PHPObjectSymbolResolver\MachO;
+
+class Segment {
+    public string $name;
+
+    public int $vmaddr;
+    public int $vmsize;
+    public int $fileoff;
+    public int $filesize;
+    public int $maxprot;
+    public int $initprot;
+    public int $nSects;
+    public int $flags;
+
+	public array $sections = [];
+}

--- a/lib/MachO/Symbol.php
+++ b/lib/MachO/Symbol.php
@@ -1,0 +1,52 @@
+<?php
+
+namespace PHPObjectSymbolResolver\MachO;
+
+class Symbol implements \PHPObjectSymbolResolver\Symbol {
+	const N_STAB = 0xe0;
+	const N_PEXT = 0x10;
+	const N_TYPE = 0x0e;
+	const N_EXT = 0x01; // exposed symbol
+
+	const N_UDF = 0x0; // undefined
+	const N_ABS = 0x2; // absolute
+	const N_SECT = 0xe; // in section nSect
+	const N_PBUD = 0xc; // undefined, prebound, in section nSect
+	const N_INDR = 0xa; // indirect, inherits other symbol by name (string offset nValue)
+
+	const REFERENCE_MASK = 0xF;
+	const REFERENCE_FLAG_UNDEFINED_NON_LAZY = 0x0;
+	const REFERENCE_FLAG_UNDEFINED_LAZY = 0x1;
+	const REFERENCE_FLAG_DEFINED = 0x2;
+	const REFERENCE_FLAG_PRIVATE_DEFINED = 0x3;
+	const REFERENCE_FLAG_PRIVATE_UNDEFINED_NON_LAZY = 0x4;
+	const REFERENCE_FLAG_PRIVATE_UNDEFINED_LAZY = 0x5;
+
+	const REFERENCED_DYNAMICALLY = 0x10;
+	const N_DESC_DISCARDED = 0x20;
+	const N_NO_DEAD_STRIP = 0x20;
+	const N_WEAK_REF = 0x40;
+	const N_WEAK_DEF = 0x80;
+
+	public int $nStrx;
+	public int $nType;
+	public int $nSect;
+	public int $nDesc;
+	public int $nValue;
+
+    public string $name;
+
+    public function isLocal(): bool {
+		$type = $this->nType & ((self::N_TYPE & ~self::N_PEXT) | self::N_EXT);
+		return $type === self::N_ABS || $type === self::N_SECT;
+    }
+
+    public function isGlobal(): bool {
+		$type = $this->nType & (self::N_TYPE | self::N_EXT);
+		return $type === (self::N_ABS | self::N_EXT) || $type === (self::N_SECT | self::N_EXT);
+    }
+
+    public function isWeak(): bool {
+        return ($this->nType & (self::N_TYPE | self::N_EXT)) === self::N_EXT;
+    }
+}

--- a/lib/MachO/SymtabCommand.php
+++ b/lib/MachO/SymtabCommand.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace PHPObjectSymbolResolver\MachO;
+
+class SymtabCommand {
+	public int $symOff;
+	public int $nSyms;
+	public int $strOff;
+	public int $strSize;
+
+	/** @var Symbol[] */
+	public array $symbols = [];
+}

--- a/lib/ObjectFile.php
+++ b/lib/ObjectFile.php
@@ -1,56 +1,13 @@
 <?php
 
-namespace PHPELFSymbolResolver;
+namespace PHPObjectSymbolResolver;
 
-class ObjectFile {
-    const CLASS32 = 1;
-    const CLASS64 = 2;
-    public int $class;
+interface ObjectFile {
+	public function is32Bit(): bool;
+	public function is64Bit(): bool;
 
-    const BYTEORDER_LSB = 1;
-    const BYTEORDER_MSB = 2;
-    public int $byteOrder;
+	public function hasLowestByteFirst(): bool;
 
-    public int $version;
-
-    public int $abi;
-
-    public int $abiVersion;
-
-    const TYPE_NONE = 0;
-    const TYPE_RELOCATABLE = 1;
-    const TYPE_EXECUTABLE = 2;
-    const TYPE_SHARD_OBJECT = 3;
-    const TYPE_CORE = 4;
-
-    public int $type;
-    public int $machine;
-    public int $eversion;
-    public int $entry;
-    public int $phoff;
-    public int $shoff;
-    public int $flags;
-    public int $phentsize;
-    public int $phnum;
-    public int $shentsize;
-    public int $shnum;
-    public int $shstrndx;
-
-    public array $sections;
-
-    public function getAllSymbols(): array {
-        $result = [];
-        foreach ($this->sections as $section) {
-            foreach ($section->symbols as $symbol) {
-                if (!$symbol->isOther(Symbol::VISIBILITY_DEFAULT)) {
-                    continue;
-                }
-                if (!$symbol->isGlobal()) {
-                    continue;
-                }
-                $result[] = $symbol->nameString;
-            }
-        }
-        return $result;
-    }
+	/** @return Symbol[] */
+	public function getAllSymbols(): array;
 }

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -1,217 +1,79 @@
 <?php
 
-namespace PHPELFSymbolResolver;
+namespace PHPObjectSymbolResolver;
 
-class Parser {
-    const HEADER = "\x7fELF";
+abstract class Parser {
+	public string $data;
+	public ObjectFile $obj;
 
-    public string $data;
-    public ObjectFile $obj;
+	public abstract function parse(string $file): ObjectFile;
 
-    public function parse(string $file) {
-        $this->data = file_get_contents($file);
-        if (strlen($this->data) < 16) {
-            throw new \LogicException("File is too short to be an ELF file");
-        }
-        if (substr($this->data, 0, 4) !== self::HEADER) {
-            throw new \LogicException("File is not in ELF format");
-        }
-        $this->obj = new ObjectFile;
-        $this->parseElfHeader();
-        $this->parseElfSections();
-        $this->parseStringSections();
-        $this->parseSymbolTables();
+	public static function parserFor(string $file): Parser {
+		$magic = file_get_contents($file, false, null, 0, 4);
+		if ($magic === ELF\Parser::HEADER) {
+			return new ELF\Parser;
+		} elseif (MachO\Parser::isValidMagic($magic)) {
+			return new MachO\Parser;
+		}
 
-        $this->data = '';
-        return $this->obj;
-    }
+		throw new \LogicException("File is neither in ELF nor Mach-O format");
+	}
 
-    protected function parseElfHeader(): void {
-        $this->obj->class = ord($this->data[4]);
-        $this->obj->byteOrder = ord($this->data[5]);
-        $this->obj->version = ord($this->data[6]);
-        $this->obj->abi = ord($this->data[7]);
-        $this->obj->abiVersion = ord($this->data[8]);
+	protected function parseAddr(int &$offset): string {
+		return $this->parseOff($offset);
+	}
 
-        $offset = 16;
-        $this->obj->type = $this->parseHalf($offset);
-        $this->obj->machine = $this->parseHalf($offset);
-        $this->obj->eversion = $this->parseWord($offset);
-        $this->obj->entry = $this->parseAddr($offset);
-        $this->obj->phoff = $this->parseOff($offset);
-        $this->obj->shoff = $this->parseOff($offset);
-        $this->obj->flags = $this->parseWord($offset);
-        $this->obj->ehsize = $this->parseHalf($offset);
-        $this->obj->phentsize = $this->parseHalf($offset);
-        $this->obj->phnum = $this->parseHalf($offset);
-        $this->obj->shentsize = $this->parseHalf($offset);
-        $this->obj->shnum = $this->parseHalf($offset);
-        $this->obj->shstrndx = $this->parseHalf($offset);
-    }
+	protected function parseHalf(int &$offset): int {
+		return $this->parseWidth(2, $offset);
+	}
 
-    protected function parseElfSections(): void {
-        $offset = $this->obj->shoff;
-        $shnum = $this->obj->shnum ?: $this->determineShnum();
-        for ($i = 0; $i < $shnum; $i++) {
-            $this->parseSectionHeader($this->obj->shoff + $i * $this->obj->shentsize);
-        }
-    }
+	protected function parseWord(int &$offset): int {
+		return $this->parseWidth(4, $offset);
+	}
 
-    protected function parseStringSections(): void {
-        $nameSection = $this->obj->sections[$this->obj->shstrndx];
-        foreach ($this->obj->sections as $section) {
-            $section->nameString = $this->readStringSectionOffset($nameSection, $section->name);
-        }
-    }
+	protected function parseXWord(int &$offset): int {
+		if ($this->obj->is64Bit()) {
+			return $this->parseWidth(8, $offset);
+		}
+		return $this->parseWidth(4, $offset);
+	}
 
-    protected function parseSymbolTables(): void {
-        foreach ($this->obj->sections as $section) {
-            if ($section->type !== Section::TYPE_SYMTAB && $section->type !== Section::TYPE_DYNSYM) {
-                continue;
-            }
-            $this->parseSymbolTable($section);
-        }
-    }
+	protected function parseUChar(int &$offset): int {
+		return $this->parseWidth(1, $offset);
+	}
 
-    protected function parseSymbolTable(Section $section) {
-        $offset = $section->offset;
-        $size = $section->size;
-        $end = $offset + $size;
-        if ($section->type === Section::TYPE_SYMTAB) {
-            $strtab = $this->findSection('.strtab');
-        } else {
-            $strtab = $this->findSection('.dynstr');
-        }
-        while ($offset < $end) {
-            $symbol = $this->parseSymbol($offset);
-            $symbol->nameString = $this->readStringSectionOffset($strtab, $symbol->name);
-            $section->symbols[] = $symbol;
-        }
+	protected function parseOff(int &$offset): int {
+		if ($this->obj->is32Bit()) {
+			return $this->parseWidth(4, $offset);
+		} elseif ($this->obj->is64Bit()) {
+			return $this->parseWidth(8, $offset);
+		}
+	}
 
-    }
+	protected function parseWidth(int $width, int &$offset): int {
+		$result = substr($this->data, $offset, $width);
+		$offset += $width;
+		return $this->stringToInt($result);
+	}
 
-    protected function findSection(string $name): Section {
-        foreach ($this->obj->sections as $section) {
-            if ($section->nameString === $name) {
-                return $section;
-            }
-        }
-        throw new \LogicException("Could not find section $name");
-    }
+	protected function parseNullTerminatedString(int $width, int &$offset): string {
+		$result = substr($this->data, $offset, $width);
+		$offset += $width;
+		$data = strstr($result, "\0", true);
+		return $data === false ? $result : $data;
+	}
 
-    protected function parseSymbol(int &$offset): Symbol {
-        $symbol = new Symbol;
-        if ($this->obj->class === ObjectFile::CLASS32) {
-            $symbol->name = $this->parseWord($offset);
-            $symbol->value = $this->parseAddr($offset);
-            $symbol->size = $this->parseWord($offset);
-            $symbol->info = $this->parseUChar($offset);
-            $symbol->other = $this->parseUChar($offset);
-            $symbol->shndx = $this->parseHalf($offset);
-        } else {
-            $symbol->name = $this->parseWord($offset);
-            $symbol->info = $this->parseUChar($offset);
-            $symbol->other = $this->parseUChar($offset);
-            $symbol->shndx = $this->parseHalf($offset);
-            $symbol->value = $this->parseAddr($offset);
-            $symbol->size = $this->parseXWord($offset);
-        }
-        return $symbol;
-    }
-
-    protected function readStringSectionOffset(Section $section, int $offset): string {
-        $mainOffset = $section->offset;
-        $size = $section->size;
-        $end = $mainOffset + $size;
-        $buffer = '';
-        for ($i = $offset + $mainOffset; $i < $end; $i++) {
-            if ($this->data[$i] === "\0") {
-                return $buffer;
-            } else {
-                $buffer .= $this->data[$i];
-            }
-        }
-        return $buffer;
-    }
-
-    protected function parseSectionHeader(int $offset): void {
-        $section = new Section;
-        $section->name = $this->parseWord($offset);
-        $section->type = $this->parseWord($offset);
-        $section->flags = $this->parseXWord($offset);
-        $section->addr = $this->parseAddr($offset);
-        $section->offset = $this->parseOff($offset);
-        $section->size = $this->parseXWord($offset);
-        $section->link = $this->parseWord($offset);
-        $section->info = $this->parseWord($offset);
-        $section->addralign = $this->parseXWord($offset);
-        $section->entsize = $this->parseXWord($offset);
-        $this->obj->sections[] = $section;
-    }
-
-    protected function parseAddr(int &$offset): string {
-        switch ($this->obj->class) {
-            case ObjectFile::CLASS32:
-                return $this->parseWidth(4, $offset);
-            case ObjectFile::CLASS64:
-                return $this->parseWidth(8, $offset);
-        }
-    }
-
-    protected function parseHalf(int &$offset): int {
-        return $this->parseWidth(2, $offset);
-    }
-
-    protected function parseSWord(int &$offset): int {
-        return $this->parseWidth(4, $offset);
-    }
-
-    protected function parseWord(int &$offset): int {
-        return $this->parseWidth(4, $offset);
-    }
-
-    protected function parseXWord(int &$offset): int {
-        if ($this->obj->class === ObjectFile::CLASS64) {
-            return $this->parseWidth(8, $offset);
-        }
-        return $this->parseWidth(4, $offset);
-    }
-
-    protected function parseUChar(int &$offset): int {
-        return $this->parseWidth(1, $offset);
-    }
-
-    protected function parseOff(int &$offset): int {
-        switch ($this->obj->class) {
-            case ObjectFile::CLASS32:
-                return $this->parseWidth(4, $offset);
-            case ObjectFile::CLASS64:
-                return $this->parseWidth(8, $offset);
-        }
-    }
-
-
-    protected function parseWidth(int $width, int &$offset): int {
-        $result = substr($this->data, $offset, $width);
-        $offset += $width;
-        return $this->stringToInt($result);
-    }
-
-    protected function stringToInt(string $string): int {
-        if ($this->obj->byteOrder === ObjectFile::BYTEORDER_LSB) {
-            $result = 0;
-            for ($i = strlen($string) - 1; $i >= 0; $i--) {
-                $result = ($result << 8) | ord($string[$i]);
-            }
-            return $result;
-        }
-        if ($this->obj->byteOrder === ObjectFile::BYTEORDER_MSB) {
-            $result = 0;
-            for ($i = 0, $n = strlen($string); $i < $n; $i++) {
-                $result = ($result << 8) | ord($string[$i]);
-            }
-            return $result;
-        }
-        throw new \LogicException("Unknown byte ordering {$this->obj->byteOrder}");
-    }
+	protected function stringToInt(string $string): int {
+		$result = 0;
+		if ($this->obj->hasLowestByteFirst()) {
+			for ($i = strlen($string) - 1; $i >= 0; $i--) {
+				$result = ($result << 8) | ord($string[$i]);
+			}
+		} else {
+			for ($i = 0, $n = strlen($string); $i < $n; $i++) {
+				$result = ($result << 8) | ord($string[$i]);
+			}
+		}
+		return $result;
+	}
 }

--- a/lib/Symbol.php
+++ b/lib/Symbol.php
@@ -1,38 +1,9 @@
 <?php
 
-namespace PHPELFSymbolResolver;
+namespace PHPObjectSymbolResolver;
 
-class Symbol {
-    const VISIBILITY_DEFAULT = 0;
-    const VISIBILITY_INTERNAL = 1;
-    const VISIBILITY_HIDDEN = 2;
-    const VISIBILITY_PROTECTED = 3;
-
-    const BINDING_LOCAL = 0;
-    const BINDING_GLOBAL = 1;
-    const BINDING_WEAK = 2;
-
-    public int $name;
-    public string $nameString;
-    public int $value;
-    public int $size;
-    public int $info;
-    public int $other;
-    public int $shndx;
-
-    public function isOther(int $other): bool {
-        return ($this->other & 0x3) === $other;
-    }
-
-    public function isLocal(): bool {
-        return ($this->info >> 4) === self::BINDING_LOCAL;
-    }
-
-    public function isGlobal(): bool {
-        return ($this->info >> 4) === self::BINDING_GLOBAL;
-    }
-
-    public function isWeak(): bool {
-        return ($this->info >> 4) === self::BINDING_WEAK;
-    }
+interface Symbol {
+	public function isLocal(): bool;
+	public function isGlobal(): bool;
+	public function isWeak(): bool;
 }


### PR DESCRIPTION
I have no idea whether you're interested in extending the scope of this, but I'd suggest considering making this library more generic (including renaming to php-object-symbolresolver).

If you're not interested, I'll just maintain this as my own fork.

This PR adds support for parsing of dylibs, i.e. MacOS libraries.