### PR TITLE
Add missing property ehsize to ObjectFile.php

### DIFF
--- a/lib/ELF/ObjectFile.php
+++ b/lib/ELF/ObjectFile.php
@@ -30,6 +30,7 @@ class ObjectFile implements \PHPObjectSymbolResolver\ObjectFile {
     public int $phoff;
     public int $shoff;
     public int $flags;
+    public int $ehsize;
     public int $phentsize;
     public int $phnum;
     public int $shentsize;


### PR DESCRIPTION
Property is referenced in https://github.com/ircmaxell/php-object-symbolresolver/blob/dfe1b1aa6c15b198bdef50fff8485e98e89f2a09/lib/ELF/Parser.php - causes deprecation error in PHP 8.2 (per https://wiki.php.net/rfc/deprecate_dynamic_properties).

From my understanding this doesn't change the public interface at all, just fixes the deprecation error.