### PR TITLE
Working implementation of a Windows Portable Executable parser.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "ircmaxell/php-object-symbolresolver",
-    "description": "An object file (ELF, Mach-O) parser",
+    "description": "An object file (ELF, Mach-O, PE) parser",
     "license": "MIT",
     "authors": [
         {
@@ -10,6 +10,10 @@
         {
             "name": "Bob Weinand",
             "email": "bobwei9@hotmail.com"
+        },
+        {
+            "name": "Shane Thompson",
+            "email": "me@shane.pt"
         }
     ],
     "require": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04a82b42082fd417dc72f4799228d927",
+    "content-hash": "592741eb6ae8a72f7d627da5b1c09c40",
     "packages": [],
     "packages-dev": [],
     "aliases": [],
@@ -15,5 +15,6 @@
     "platform": {
         "php": ">=7.4"
     },
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "2.3.0"
 }

--- a/lib/PE/DelayedLoadDirectoryEntry.php
+++ b/lib/PE/DelayedLoadDirectoryEntry.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace PHPObjectSymbolResolver\PE;
+
+class DelayedLoadDirectoryEntry extends ImportLookupTableEntry {
+    public function isWeak(): bool {
+        return true;
+    }
+}

--- a/lib/PE/ExportTableEntry.php
+++ b/lib/PE/ExportTableEntry.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace PHPObjectSymbolResolver\PE;
+
+class ExportTableEntry extends Symbol {
+    /**
+     * This structure is 20 bytes long.
+     */
+    const SIZEOF = 20;
+
+    public int $nameRva;
+    public int $ordinal;
+    public int $address;
+    public bool $isForwarder;
+    public ?string $forwarderString = null;
+}

--- a/lib/PE/ImportDirectoryEntry.php
+++ b/lib/PE/ImportDirectoryEntry.php
@@ -1,0 +1,18 @@
+<?php
+
+namespace PHPObjectSymbolResolver\PE;
+
+class ImportDirectoryEntry {
+    /**
+     * This structure is 20 bytes long.
+     */
+    const SIZEOF = 20;
+
+    public int $importLookupTableRva;
+    public int $timeDateStamp;
+    public int $forwarderChain;
+    public int $nameRva;
+    public int $importAddressTableRva;
+
+    public string $dllFilename;
+}

--- a/lib/PE/ImportLookupTableEntry.php
+++ b/lib/PE/ImportLookupTableEntry.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace PHPObjectSymbolResolver\PE;
+
+class ImportLookupTableEntry extends Symbol {
+    public bool $isOrdinal;
+    public int $ordinal;
+    public int $hint;
+    public string $name;
+    public string $dllFilename;
+}

--- a/lib/PE/ImportLookupTableEntry.php
+++ b/lib/PE/ImportLookupTableEntry.php
@@ -6,6 +6,6 @@ class ImportLookupTableEntry extends Symbol {
     public bool $isOrdinal;
     public int $ordinal;
     public int $hint;
-    public string $name;
+
     public string $dllFilename;
 }

--- a/lib/PE/ObjectFile.php
+++ b/lib/PE/ObjectFile.php
@@ -1,0 +1,696 @@
+<?php
+
+namespace PHPObjectSymbolResolver\PE;
+
+class ObjectFile implements \PHPObjectSymbolResolver\ObjectFile {
+    // The path to the ObjectFile.
+    public string $filepath;
+
+    public int $oemid;
+    public int $oeminfo;
+    public int $lfanew;
+
+
+    /**
+     * The number that identifies the type of target machine. See the machine
+     * type constants.
+     */
+    public int $machine;
+
+    /**
+     * Machine Type constants.
+     *
+     * The Machine field has one of the following values, which specify the CPU
+     * type. An image file can be run only on the specified machine or on a
+     * system that emulates the specified machine.
+     *
+     * @see https://learn.microsoft.com/en-gb/windows/win32/debug/pe-format#machine-types
+     *
+     * @var int
+     */
+    const IMAGE_FILE_MACHINE_UNKNOWN = 0x0;
+    const IMAGE_FILE_MACHINE_ALPHA = 0x184;
+    const IMAGE_FILE_MACHINE_ALPHA64 = 0x284;
+    const IMAGE_FILE_MACHINE_AM33 = 0x1d3;
+    const IMAGE_FILE_MACHINE_AMD64 = 0x8664;
+    const IMAGE_FILE_MACHINE_ARM = 0x1c0;
+    const IMAGE_FILE_MACHINE_ARM64 = 0xaa64;
+    const IMAGE_FILE_MACHINE_ARMNT = 0x1c4;
+    const IMAGE_FILE_MACHINE_AXP64 = 0x284;
+    const IMAGE_FILE_MACHINE_EBC = 0xebc;
+    const IMAGE_FILE_MACHINE_I386 = 0x14c;
+    const IMAGE_FILE_MACHINE_IA64 = 0x200;
+    const IMAGE_FILE_MACHINE_LOONGARCH32 = 0x6232;
+    const IMAGE_FILE_MACHINE_LOONGARCH64 = 0x6264;
+    const IMAGE_FILE_MACHINE_M32R = 0x9041;
+    const IMAGE_FILE_MACHINE_MIPS16 = 0x266;
+    const IMAGE_FILE_MACHINE_MIPSFPU = 0x366;
+    const IMAGE_FILE_MACHINE_MIPSFPU16 = 0x466;
+    const IMAGE_FILE_MACHINE_POWERPC = 0x1f0;
+    const IMAGE_FILE_MACHINE_POWERPCFP = 0x1f1;
+    const IMAGE_FILE_MACHINE_R4000 = 0x166;
+    const IMAGE_FILE_MACHINE_RISCV32 = 0x5032;
+    const IMAGE_FILE_MACHINE_RISCV64 = 0x5064;
+    const IMAGE_FILE_MACHINE_RISCV128 = 0x5128;
+    const IMAGE_FILE_MACHINE_SH3 = 0x1a2;
+    const IMAGE_FILE_MACHINE_SH3DSP = 0x1a3;
+    const IMAGE_FILE_MACHINE_SH4 = 0x1a6;
+    const IMAGE_FILE_MACHINE_SH5 = 0x1a8;
+    const IMAGE_FILE_MACHINE_THUMB = 0x1c2;
+    const IMAGE_FILE_MACHINE_WCEMIPSV2 = 0x169;
+
+    /**
+     * The number of sections. This indicates the size of the section table,
+     * which immediately follows the headers.
+     */
+    public int $numberOfSections;
+
+    /**
+     * The low 32 bits of the number of seconds since 00:00 January 1, 1970
+     * (a C run-time time_t value), which indicates when the file was created.
+     */
+    public int $timeDateStamp;
+
+    /**
+     * The file offset of the COFF symbol table, or zero if no COFF symbol table
+     * is present. This value should be zero for an image because COFF debugging
+     * information is deprecated.
+     */
+    public int $pointerToSymbolTable;
+
+    /**
+     * The number of entries in the symbol table. This data can be used to
+     * locate the string table, which immediately follows the symbol table. This
+     * value should be zero for an image because COFF debugging information is
+     * deprecated.
+     */
+    public int $numberOfSymbols;
+
+    /**
+     * The size of the optional header, which is required for executable files
+     * but not for object files. This value should be zero for an object file.
+     */
+    public int $sizeOfOptionalHeader;
+
+    /**
+     * The flags that indicate the attributes of the file. See Characteristics
+     * constants.
+     */
+    public int $characteristics;
+
+    /**
+     * Characteristics constants.
+     *
+     * The Characteristics field contains flags that indicate attributes of the
+     * object or image file.
+     *
+     * @see https://learn.microsoft.com/en-gb/windows/win32/debug/pe-format?redirectedfrom=MSDN#characteristics
+     *
+     * @var int
+     */
+    const IMAGE_FILE_RELOCS_STRIPPED = 0x0001;
+    const IMAGE_FILE_EXECUTABLE_IMAGE = 0x0002;
+    const IMAGE_FILE_LINE_NUMS_STRIPPED = 0x0004;
+    const IMAGE_FILE_LOCAL_SYMS_STRIPPED = 0x0008;
+    const IMAGE_FILE_AGGRESSIVE_WS_TRIM = 0x0010;
+    const IMAGE_FILE_LARGE_ADDRESS_AWARE = 0x0020;
+    const IMAGE_FILE_BYTES_REVERSED_LO = 0x0080;
+    const IMAGE_FILE_32BIT_MACHINE = 0x0100;
+    const IMAGE_FILE_DEBUG_STRIPPED = 0x0200;
+    const IMAGE_FILE_REMOVABLE_RUN_FROM_SWAP = 0x0400;
+    const IMAGE_FILE_NET_RUN_FROM_SWAP = 0x0800;
+    const IMAGE_FILE_SYSTEM = 0x1000;
+    const IMAGE_FILE_DLL = 0x2000;
+    const IMAGE_FILE_UP_SYSTEM_ONLY = 0x4000;
+    const IMAGE_FILE_BYTES_REVERSED_HI = 0x8000;
+
+    /**
+     * This is NOT part of the PE format. It is a helper variable to find the
+     * COFF string table.
+     */
+    public int $pointerToStringTable;
+
+    /**
+     * This is NOT part of the PE format. It is a helper variable to contain the
+     * size of the COFF string table.
+     */
+    public int $stringTableSize;
+
+    /**
+     * Begin Optional Header definition.
+     */
+
+    /**
+     * The Optional Header Magic Number determines whether an image is PE32 or
+     * PE32+ (64-bit). Se PE Format constants for more details.
+     */
+    public int $peFormat;
+
+    /**
+     * PE Format constants.
+     */
+    const PE32 = 0x10b;
+    const PE32_PLUS = 0x20b;
+    const ROM_IMAGE = 0x107;
+
+    /**
+     * The linker major version number.
+     */
+    public int $majorLinkerVersion;
+
+    /**
+     * The linker minor version number.
+     */
+    public int $minorLinkerVersion;
+
+    /**
+     * The size of the code (text) section, or the sum of all code sections if
+     * there are multiple sections.
+     */
+    public int $sizeOfCode;
+
+    /**
+     * The size of the initialized data section, or the sum of all such sections
+     * if there are multiple data sections.
+     */
+    public int $sizeOfInitializedData;
+
+    /**
+     * The size of the uninitialized data section (BSS), or the sum of all such
+     * sections if there are multiple BSS sections.
+     */
+    public int $sizeOfUninitializedData;
+
+    /**
+     * The address of the entry point relative to the image base when the
+     * executable file is loaded into memory. For program images, this is the
+     * starting address. For device drivers, this is the address of the
+     * initialization function. An entry point is optional for DLLs. When no
+     * entry point is present, this field must be zero.
+     */
+    public int $addressOfEntryPoint;
+
+    /**
+     * The address that is relative to the image base of the beginning-of-code
+     * section when it is loaded into memory.
+     */
+    public int $baseOfCode;
+
+    /**
+     * The address that is relative to the image base of the beginning-of-data
+     * section when it is loaded into memory. This field is only present for
+     * PE32, and is absent in PE32+.
+     */
+    public int $baseOfData;
+
+    /**
+     * The preferred address of the first byte of image when loaded into memory;
+     * must be a multiple of 64 K. The default for DLLs is 0x10000000. The
+     * default for Windows CE EXEs is 0x00010000. The default for Windows NT,
+     * Windows 2000, Windows XP, Windows 95, Windows 98, and Windows Me is
+     * 0x00400000.
+     */
+    public int $imageBase;
+
+    /**
+     * The alignment (in bytes) of sections when they are loaded into memory. It
+     * must be greater than or equal to FileAlignment. The default is the page
+     * size for the architecture.
+     */
+    public int $sectionAlignment;
+
+    /**
+     * The alignment factor (in bytes) that is used to align the raw data of
+     * sections in the image file. The value should be a power of 2 between 512
+     * and 64 K, inclusive. The default is 512. If the SectionAlignment is less
+     * than the architecture's page size, then FileAlignment must match
+     * SectionAlignment.
+     */
+    public int $fileAlignment;
+
+    /**
+     * The major version number of the required operating system.
+     */
+    public int $majorOperatingSystemVersion;
+
+    /**
+     * The minor version number of the required operating system.
+     */
+    public int $minorOperatingSystemVersion;
+
+    /**
+     * The major version number of the image.
+     */
+    public int $majorImageVersion;
+
+    /**
+     * The minor version number of the image.
+     */
+    public int $minorImageVersion;
+
+    /**
+     * The major version number of the subsystem.
+     */
+    public int $majorSubsystemVersion;
+
+    /**
+     * The minor version number of the subsystem.
+     */
+    public int $minorSubsystemVersion;
+
+    /**
+     * Reserved, must be zero.
+     */
+    public int $win32VersionValue;
+
+    /**
+     * The size (in bytes) of the image, including all headers, as the image is
+     * loaded in memory. It must be a multiple of SectionAlignment.
+     */
+    public int $sizeOfImage;
+
+    /**
+     * The combined size of an MS-DOS stub, PE header, and section headers
+     * rounded up to a multiple of FileAlignment.
+     */
+    public int $sizeOfHeaders;
+
+    /**
+     * The image file checksum.
+     */
+    public int $checksum;
+
+    /**
+     * The subsystem that is required to run this image. See Windows Subsystem
+     * constants.
+     */
+    public int $subsystem;
+
+    /**
+     * Windows Subsystem constants.
+     *
+     * @see https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#windows-subsystem
+     */
+    const IMAGE_SUBSYSTEM_UNKNOWN = 0;
+    const IMAGE_SUBSYSTEM_NATIVE = 1;
+    const IMAGE_SUBSYSTEM_WINDOWS_GUI = 2;
+    const IMAGE_SUBSYSTEM_WINDOWS_CUI = 3;
+    const IMAGE_SUBSYSTEM_OS2_CUI = 5;
+    const IMAGE_SUBSYSTEM_POSIX_CUI = 7;
+    const IMAGE_SUBSYSTEM_NATIVE_WINDOWS = 8;
+    const IMAGE_SUBSYSTEM_WINDOWS_CE_GUI = 9;
+    const IMAGE_SUBSYSTEM_EFI_APPLICATION = 10;
+    const IMAGE_SUBSYSTEM_EFI_BOOT_SERVICE_DRIVER = 11;
+    const IMAGE_SUBSYSTEM_EFI_RUNTIME_DRIVER = 12;
+    const IMAGE_SUBSYSTEM_EFI_ROM = 13;
+    const IMAGE_SUBSYSTEM_XBOX = 14;
+    const IMAGE_SUBSYSTEM_WINDOWS_BOOT_APPLICATION = 16;
+
+    /**
+     * Defines different characteristics of the image, if it is a DLL. See DLL
+     * Characteristics constants.
+     */
+    public int $dllCharacteristics;
+
+    /**
+     * DLL Characteristics constants.
+     *
+     * @see https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#dll-characteristics
+     */
+    const IMAGE_DLLCHARACTERISTICS_HIGH_ENTROPY_VA = 0x0020;
+    const IMAGE_DLLCHARACTERISTICS_DYNAMIC_BASE = 0x0040;
+    const IMAGE_DLLCHARACTERISTICS_FORCE_INTEGRITY = 0x0080;
+    const IMAGE_DLLCHARACTERISTICS_NX_COMPAT = 0x0100;
+    const IMAGE_DLLCHARACTERISTICS_NO_ISOLATION = 0x0200;
+    const IMAGE_DLLCHARACTERISTICS_NO_SEH = 0x0400;
+    const IMAGE_DLLCHARACTERISTICS_NO_BIND = 0x0800;
+    const IMAGE_DLLCHARACTERISTICS_APPCONTAINER = 0x1000;
+    const IMAGE_DLLCHARACTERISTICS_WDM_DRIVER = 0x2000;
+    const IMAGE_DLLCHARACTERISTICS_GUARD_CF = 0x4000;
+    const IMAGE_DLLCHARACTERISTICS_TERMINAL_SERVER_AWARE = 0x8000;
+
+    /**
+     * The size of the stack to reserve. Only SizeOfStackCommit is committed;
+     * the rest is made available one page at a time until the reserve size is
+     * reached.
+     */
+    public int $sizeOfStackReserve;
+
+    /**
+     * The size of the stack to commit.
+     */
+    public int $sizeOfStackCommit;
+
+    /**
+     * The size of the local heap space to reserve. Only SizeOfHeapCommit is
+     * committed; the rest is made available one page at a time until the
+     * reserve size is reached.
+     */
+    public int $sizeOfHeapReserve;
+
+    /**
+     * The size of the local heap space to commit.
+     */
+    public int $sizeOfHeapCommit;
+
+    /**
+     * Reserved, must be zero.
+     */
+    public int $loaderFlags;
+
+    /**
+     * The number of data-directory entries in the remainder of the optional
+     * header. Each describes a location and size.
+     */
+    public int $numberOfRvaAndSizes;
+
+    /**
+     * The export table (.edata) address.
+     */
+    public int $exportTableRva;
+
+    /**
+     * The export data (.edata) size.
+     */
+    public int $exportTableSize;
+
+    /**
+     * The import data (.idata) address.
+     */
+    public int $importTableRva;
+
+    /**
+     * The import data (.idata) size.
+     */
+    public int $importTableSize;
+
+    /**
+     * The resource table (.rsrc) address.
+     */
+    public int $resourceTableRva;
+
+    /**
+     * The resource table (.rsrc) size.
+     */
+    public int $resourceTableSize;
+
+    /**
+     * The exception table address.
+     */
+    public int $exceptionTableRva;
+
+    /**
+     * The exception table size.
+     */
+    public int $exceptionTableSize;
+
+    /**
+     * The attribute certificate table address.
+     */
+    public int $certificateTableRva;
+
+    /**
+     * The attribute certificate table size.
+     */
+    public int $certificateTableSize;
+
+    /**
+     * The base relocation table address.
+     */
+    public int $baseRelocationTableRva;
+
+    /**
+     * The base relocation table size.
+     */
+    public int $baseRelocationTableSize;
+
+    /**
+     * The debug data starting address.
+     */
+    public int $debugRva;
+
+    /**
+     * The debug data size.
+     */
+    public int $debugSize;
+
+    /**
+     * Reserved, must be 0.
+     */
+    public int $architectureRva;
+
+    /**
+     * Reserved, must be 0.
+     */
+    public int $architectureSize;
+
+    /**
+     * The address of the value to be stored in the global pointer register.
+     */
+    public int $globalPtrRva;
+
+    /**
+     * Reserved, must be 0.
+     */
+    public int $globalPtrSize;
+
+    /**
+     * The thread local storage (TLS) table address.
+     */
+    public int $tlsTableRva;
+
+    /**
+     * The thread local storage (TLS) table size.
+     */
+    public int $tlsTableSize;
+
+    /**
+     * The load configuration table address.
+     */
+    public int $loadConfigTableRva;
+
+    /**
+     * The load configuration table size.
+     */
+    public int $loadConfigTableSize;
+
+    /**
+     * The bound import table address.
+     */
+    public int $boundImportRva;
+
+    /**
+     * The bound import table size.
+     */
+    public int $boundImportSize;
+
+    /**
+     * The import address table address.
+     */
+    public int $iatRva;
+
+    /**
+     * The import address table size.
+     */
+    public int $iatSize;
+
+    /**
+     * The delay import descriptor address.
+     */
+    public int $delayImportDescriptorRva;
+
+    /**
+     * The delay import descriptor size.
+     */
+    public int $delayImportDescriptorSize;
+
+    /**
+     * The CLR runtime header address.
+     */
+    public int $clrRuntimeHeaderRva;
+
+    /**
+     * The CLR runtime header size.
+     */
+    public int $clrRuntimeHeaderSize;
+
+    /**
+     * @var Section[]
+     */
+    public array $sections;
+
+    /**
+     * @var ?ObjectFile[]
+     */
+    public ?array $importedObjects = null;
+
+    /**
+     * @var string[]
+     */
+    private static ?array $sharedLibrarySearchDirectories = null;
+
+    public function is32Bit(): bool {
+        return $this->peFormat === self::PE32;
+    }
+
+    public function is64Bit(): bool {
+        return $this->peFormat === self::PE32_PLUS;
+    }
+
+    public function hasLowestByteFirst(): bool {
+        return true;
+    }
+
+    protected function findSection($name) {
+        foreach ($this->sections as $section) {
+            if ($name === $section->name) {
+                return $section;
+            }
+        }
+
+        throw new \LogicException(sprintf(
+            'Unable to find the specified section "%s".',
+            $name
+        ));
+    }
+
+    public static function getSharedSearchPaths(): array {
+        $sysdrive = getenv('SystemDrive') or 'C:';
+        $sysdir = getenv('SystemRoot') or "$sysdrive\\Windows";
+
+        if (self::$sharedLibrarySearchDirectories === null) {
+            self::$sharedLibrarySearchDirectories = ["$sysdir\\System32"];
+
+            if (is_dir("$sysdir\\SysWOW64")) {
+                self::$sharedLibrarySearchDirectories[] = "$sysdir\\SysWOW64";
+            }
+
+            self::$sharedLibrarySearchDirectories[] = $sysdir;
+            self::$sharedLibrarySearchDirectories[] = '%filepath%';
+
+            $envPaths = explode(PATH_SEPARATOR, getenv('PATH'));
+            self::$sharedLibrarySearchDirectories =
+                array_merge(self::$sharedLibrarySearchDirectories, $envPaths);
+        }
+
+        return self::$sharedLibrarySearchDirectories;
+    }
+
+    public static function addSharedSearchDirectory($path) {
+        self::getSharedSearchPaths();
+        self::$sharedLibrarySearchDirectories[] = rtrim($path, DIRECTORY_SEPARATOR);
+    }
+
+    protected function findDependencyPath($filename) {
+        foreach (self::getSharedSearchPaths() as $path) {
+            if ('%filepath%' === $path) {
+                $path = rtrim(dirname($this->filepath), DIRECTORY_SEPARATOR);
+            }
+
+            if ($realpath = realpath($path . DIRECTORY_SEPARATOR . $filename)) {
+                return $realpath;
+            }
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Location of dependency "%s" could not be found in search paths.',
+            $filename
+        ));
+    }
+
+    public function resolveDependentObjectsRecursively(&$objects = []) {
+        $dependencies = [];
+        $importSection = $this->findSection('.idata');
+        $exportSection = $this->findSection('.edata');
+
+        if (! is_null($importSection)) {
+            foreach ($importSection->symbols as $symbol) {
+                $dependencies[] = $symbol->dllFilename;
+            }
+        }
+
+        if (! is_null($exportSection)) {
+            foreach ($exportSection->symbols as $symbol) {
+                $objects[$symbol->nameString] = $this;
+            }
+        }
+
+        foreach ($dependencies as $dependency) {
+            $path = $this->findDependencyPath($dependency);
+
+            // This dependency has already been resolved.
+            if (isset($objects[$dependency]) || isset($objects[$path])) {
+                continue;
+            }
+
+            $parser = \PHPObjectSymbolResolver\Parser::parseFor($path);
+            $parser->resolveDependentObjectsRecursively($objects);
+        }
+
+        return $objects;
+    }
+
+    /**
+     * @return string[]
+     */
+	public function getAllSymbols(): array {
+        $result = [];
+
+        foreach ($this->sections as $section) {
+            foreach ($section->symbols as $symbol) {
+                $result[] = $symbol->nameString;
+            }
+        }
+
+        return $result;
+    }
+
+	/**
+     * @return string[]
+     */
+	public function getAllSymbolsRecursively(): array {
+        if ($this->importedObjects === null) {
+            $this->importedObjects = $this->resolveDependentObjectsRecursively();
+        }
+
+        $symbols = $this->getAllSymbols();
+
+        foreach ($this->importedObjects as $object) {
+            array_push($symbols, ...$object->getAllSymbols());
+        }
+
+        return array_unique($symbols);
+    }
+
+    /**
+     * Translates a Relative Virtual Address to a physical file offset.
+     *
+     * @param int $relativeVirtualAddress The RVA to translate.
+     *
+     * @return ?int The translated address, or NULL on failure.
+     */
+    public function translateRva(int $relativeVirtualAddress): int {
+        foreach ($this->sections as $section) {
+            $startVirtualAddress = $section->virtualAddress;
+            $endVirtualAddress = $startVirtualAddress + $section->virtualSize;
+
+            if ($relativeVirtualAddress < $startVirtualAddress) {
+                continue;
+            }
+
+            if ($relativeVirtualAddress > $endVirtualAddress) {
+                continue;
+            }
+
+            // Remove the virtual offset and base offset and add the physical one.
+            $sectionOffset = $relativeVirtualAddress - $startVirtualAddress;
+            return $section->pointerToRawData + $sectionOffset;
+        }
+
+        throw new \RuntimeException(sprintf(
+            'Could not translate RVA 0x%x as we could not determine which ' .
+            'section it is contained within.',
+            $relativeVirtualAddress
+        ));
+    }
+}

--- a/lib/PE/Parser.php
+++ b/lib/PE/Parser.php
@@ -1,0 +1,579 @@
+<?php
+/**
+ * Defines a parser for processing Windows Portable Executable files.
+ *
+ * @author Shane Thompson
+ */
+namespace PHPObjectSymbolResolver\PE;
+
+/**
+ * Useful URLs:
+ *
+ * - https://github.com/cubiclesoft/php-winpefile/blob/master/support/win_pe_file.php
+ * - https://upload.wikimedia.org/wikipedia/commons/1/1b/Portable_Executable_32_bit_Structure_in_SVG_fixed.svg
+ */
+
+/**
+ * @see https://learn.microsoft.com/en-gb/windows/win32/debug/pe-format
+ */
+class Parser extends \PHPObjectSymbolResolver\Parser {
+    const HEADER = "MZ";
+
+    public function parse(string $file): ObjectFile {
+        $this->data = file_get_contents($file);
+
+        if (substr($this->data, 0, 2) !== self::HEADER) {
+            throw new \LogicException("File is not in PE format");
+        }
+
+        $this->obj = new ObjectFile;
+        $this->obj->filepath = $file;
+        $this->parsePeHeaders();
+        $this->parsePeSectionHeaders();
+        $this->parseImportTable();
+        $this->parseDelayedLoadTable();
+        $this->parseExportTable();
+
+        $this->data = '';
+        return $this->obj;
+    }
+
+    public static function isPortableExecutable(string $file): bool {
+        $fh = fopen($file, 'rb');
+
+        // Must contain MS-DOS magic number.
+        if ('MZ' !== fread($fh, 2)) {
+            fclose($fh);
+            return false;
+        }
+
+        // Get lfanew from offset 0x3c to test PE header.
+        fseek($fh, 0x3c);
+        $peHeaderAddress = fread($fh, 4);
+        $peHeaderAddress = unpack('Vaddr', $peHeaderAddress)['addr'];
+
+        fseek($fh, $peHeaderAddress);
+
+        $peSignature = fread($fh, 4);
+        fclose($fh);
+        $peSignature = unpack('Vsig', $peSignature)['sig'];
+
+        return 0x4550 === $peSignature;
+    }
+
+    protected function parsePeHeaders(): void {
+        /**
+         * Skip the MS-DOS header, only getting the lfanew parameter.
+         */
+        $offset = 0x3c;
+        $this->obj->lfanew = $this->parseWord($offset);
+
+        /**
+         * Now we must parse the COFF header.
+         */
+        $offset = $this->obj->lfanew;
+        $peSignature = $this->parseWord($offset);
+
+        if (0x4550 !== $peSignature) {
+            throw new \LogicException(
+                "PE header missing. File is not a valid PE object."
+            );
+        }
+
+        $this->obj->machine = $this->parseHalf($offset);
+        $this->obj->numberOfSections = $this->parseHalf($offset);
+        $this->obj->timeDateStamp = $this->parseWord($offset);
+        $this->obj->pointerToSymbolTable = $this->parseWord($offset);
+        $this->obj->numberOfSymbols = $this->parseWord($offset);
+        $this->obj->sizeOfOptionalHeader = $this->parseHalf($offset);
+        $this->obj->characteristics = $this->parseHalf($offset);
+
+        /**
+         * Let us calculate the position of the COFF string table while we are
+         * here. The string table is always directly after the COFF symbol
+         * table. The first 4 bytes of the string table are the size of the
+         * string table, so we will skip that and assign it to its own variable.
+         */
+        $this->obj->pointerToStringTable = $this->obj->pointerToSymbolTable +
+            ($this->obj->numberOfSymbols * 18) + 4;
+        $pointerToSize = $this->obj->pointerToStringTable - 4;
+        $this->obj->stringTableSize = $this->parseWord($pointerToSize);
+
+        /**
+         * We have no optional headers to pass. Although this is a valid COFF
+         * executable, it's not really helpful for us...
+         */
+        if (! $this->obj->sizeOfOptionalHeader) {
+            throw new \LogicException(
+                "Missing Optional PE Headers. File can not be parsed."
+            );
+        }
+
+        $this->obj->peFormat = $this->parseHalf($offset);
+        $this->obj->majorLinkerVersion = ord($this->data[$offset+0]);
+        $this->obj->minorLinkerVersion = ord($this->data[$offset+1]);
+        $offset += 2;
+        $this->obj->sizeOfCode = $this->parseWord($offset);
+        $this->obj->sizeOfInitializedData = $this->parseWord($offset);
+        $this->obj->sizeOfUninitializedData = $this->parseWord($offset);
+        $this->obj->addressOfEntryPoint = $this->parseWord($offset);
+        $this->obj->baseOfCode = $this->parseWord($offset);
+
+        // This field only exists on 32-bit object files.
+        if ($this->obj->is64Bit()) {
+            $this->obj->baseOfData = -1;
+        } else {
+            $this->obj->baseOfData = $this->parseWord($offset);
+        }
+
+        $this->obj->imageBase = $this->parseXWord($offset);
+        $this->obj->sectionAlignment = $this->parseWord($offset);
+        $this->obj->fileAlignment = $this->parseWord($offset);
+        $this->obj->majorOperatingSystemVersion = $this->parseHalf($offset);
+        $this->obj->minorOperatingSystemVersion = $this->parseHalf($offset);
+        $this->obj->majorImageVersion = $this->parseHalf($offset);
+        $this->obj->minorImageVersion = $this->parseHalf($offset);
+        $this->obj->majorSubsystemVersion = $this->parseHalf($offset);
+        $this->obj->minorSubsystemVersion = $this->parseHalf($offset);
+        $this->obj->win32VersionValue = $this->parseWord($offset);
+        $this->obj->sizeOfImage = $this->parseWord($offset);
+        $this->obj->sizeOfHeaders = $this->parseWord($offset);
+        $this->obj->checksum = $this->parseWord($offset);
+        $this->obj->subsystem = $this->parseHalf($offset);
+        $this->obj->dllCharacteristics = $this->parseHalf($offset);
+        $this->obj->sizeOfStackReserve = $this->parseXWord($offset);
+        $this->obj->sizeOfStackCommit = $this->parseXWord($offset);
+        $this->obj->sizeOfHeapReserve = $this->parseXWord($offset);
+        $this->obj->sizeOfHeapCommit = $this->parseXWord($offset);
+        $this->obj->loaderFlags = $this->parseWord($offset);
+        $this->obj->numberOfRvaAndSizes = $this->parseWord($offset);
+
+        /**
+         * Optional Header Data Directories. There are 16 possible values, we
+         * must check with numberOfRvaAndSizes prior to each one to ensure we
+         * don't overflow into the next section.
+         */
+        if ($this->obj->numberOfRvaAndSizes > 0) {
+            $this->obj->exportTableRva = $this->parseWord($offset);
+            $this->obj->exportTableSize = $this->parseWord($offset);
+        } else {
+            $this->obj->exportTableRva = 0;
+            $this->obj->exportTableSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 1) {
+            $this->obj->importTableRva = $this->parseWord($offset);
+            $this->obj->importTableSize = $this->parseWord($offset);
+        } else {
+            $this->obj->importTableRva = 0;
+            $this->obj->importTableSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 2) {
+            $this->obj->resourceTableRva = $this->parseWord($offset);
+            $this->obj->resourceTableSize = $this->parseWord($offset);
+        } else {
+            $this->obj->resourceTableRva = 0;
+            $this->obj->resourceTableSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 3) {
+            $this->obj->exceptionTableRva = $this->parseWord($offset);
+            $this->obj->exceptionTableSize = $this->parseWord($offset);
+        } else {
+            $this->obj->exceptionTableRva = 0;
+            $this->obj->exceptionTableSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 4) {
+            $this->obj->certificateTableRva = $this->parseWord($offset);
+            $this->obj->certificateTableSize = $this->parseWord($offset);
+        } else {
+            $this->obj->certificateTableRva = 0;
+            $this->obj->certificateTableSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 5) {
+            $this->obj->baseRelocationTableRva = $this->parseWord($offset);
+            $this->obj->baseRelocationTableSize = $this->parseWord($offset);
+        } else {
+            $this->obj->baseRelocationTableRva = 0;
+            $this->obj->baseRelocationTableSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 6) {
+            $this->obj->debugRva = $this->parseWord($offset);
+            $this->obj->debugSize = $this->parseWord($offset);
+        } else {
+            $this->obj->debugRva = 0;
+            $this->obj->debugSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 7) {
+            $this->obj->architectureRva = $this->parseWord($offset);
+            $this->obj->architectureSize = $this->parseWord($offset);
+        } else {
+            $this->obj->architectureRva = 0;
+            $this->obj->architectureSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 8) {
+            $this->obj->globalPtrRva = $this->parseWord($offset);
+            $this->obj->globalPtrSize = $this->parseWord($offset);
+        } else {
+            $this->obj->globalPtrRva = 0;
+            $this->obj->globalPtrSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 9) {
+            $this->obj->tlsTableRva = $this->parseWord($offset);
+            $this->obj->tlsTableSize = $this->parseWord($offset);
+        } else {
+            $this->obj->tlsTableRva = 0;
+            $this->obj->tlsTableSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 10) {
+            $this->obj->loadConfigTableRva = $this->parseWord($offset);
+            $this->obj->loadConfigTableSize = $this->parseWord($offset);
+        } else {
+            $this->obj->loadConfigTableRva = 0;
+            $this->obj->loadConfigTableSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 11) {
+            $this->obj->boundImportRva = $this->parseWord($offset);
+            $this->obj->boundImportSize = $this->parseWord($offset);
+        } else {
+            $this->obj->boundImportRva = 0;
+            $this->obj->boundImportSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 12) {
+            $this->obj->iatRva = $this->parseWord($offset);
+            $this->obj->iatSize = $this->parseWord($offset);
+        } else {
+            $this->obj->iatRva = 0;
+            $this->obj->iatSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 13) {
+            $this->obj->delayImportDescriptorRva = $this->parseWord($offset);
+            $this->obj->delayImportDescriptorSize = $this->parseWord($offset);
+        } else {
+            $this->obj->delayImportDescriptorRva = 0;
+            $this->obj->delayImportDescriptorSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 14) {
+            $this->obj->clrRuntimeHeaderRva = $this->parseWord($offset);
+            $this->obj->clrRuntimeHeaderSize = $this->parseWord($offset);
+        } else {
+            $this->obj->clrRuntimeHeaderRva = 0;
+            $this->obj->clrRuntimeHeaderSize = 0;
+        }
+        if ($this->obj->numberOfRvaAndSizes > 15) {
+            $reserved = $this->parseWidth(8, $offset);
+        } else {
+            $reserved = 0;
+        }
+
+        // The following must all be zero. If any of them are not, we error.
+        if (
+            $this->obj->pointerToSymbolTable +
+            $this->obj->numberOfSymbols +
+            $this->obj->win32VersionValue +
+            $this->obj->loaderFlags +
+            $this->obj->architectureRva +
+            $this->obj->architectureSize +
+            $this->obj->globalPtrSize +
+            $reserved
+        ) {
+            throw new \LogicException(
+                'File is an invalid PE object. Data found in reserved field.'
+            );
+        }
+    }
+
+    protected function parsePeSectionHeaders() {
+        // PE header position + PE header length + optional headers length
+        $offset = $this->obj->lfanew + 24 + $this->obj->sizeOfOptionalHeader;
+        $numEntries = $this->obj->numberOfSections;
+        $sectionEntryLength = 40;
+
+        for ($i = 0; $i < $numEntries; $i++) {
+            $this->parsePeSection($offset + $sectionEntryLength * $i);
+        }
+    }
+
+    /**
+     * @see https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers
+     */
+    protected function parsePeSection($offset) {
+        $section = new Section();
+
+        $section->offset = $offset;
+        $section->name = $this->parseString($offset, 8);
+        $section->virtualSize = $this->parseWord($offset);
+        $section->virtualAddress = $this->parseWord($offset);
+        $section->sizeOfRawData = $this->parseWord($offset);
+        $section->pointerToRawData = $this->parseWord($offset);
+        $section->pointerToRelocations = $this->parseWord($offset);
+        $section->pointerToLineNumbers = $this->parseWord($offset);
+        $section->numberOfRelocations = $this->parseHalf($offset);
+        $section->numberOfLineNumbers = $this->parseHalf($offset);
+        $section->characteristics = $this->parseWord($offset);
+
+        $this->obj->sections[] = $section;
+    }
+
+    protected function parseImportTable(): void {
+        // If we have no import table, skip.
+        if (! $this->obj->importTableSize) {
+            return;
+        }
+
+        $importTableOffset = $this->obj->translateRva($this->obj->importTableRva);
+        $directoryEntrySize = ImportDirectoryEntry::SIZEOF;
+
+        $section = new Section;
+        $section->name = '.idata';
+        $section->virtualAddress = $this->obj->importTableRva;
+        $section->virtualSize = $this->obj->importTableSize;
+        $section->sizeOfRawData = $this->obj->importTableSize;
+        $section->pointerToRawData = $importTableOffset;
+
+        $symbolCount = $section->sizeOfRawData / $directoryEntrySize - 1;
+        $directories = [];
+
+        // Loop through
+        for ($i = 0; $i < $symbolCount; $i++) {
+            $offset = ($i * $directoryEntrySize) + $importTableOffset;
+            $directory = $this->parseImportDirectoryEntry($offset);
+            $directories[] = $directory;
+        }
+
+        $lastOffset = ($symbolCount * $directoryEntrySize) + $importTableOffset;
+        $expect = str_repeat("\x0", $directoryEntrySize);
+        $found = substr($this->data, $lastOffset, $directoryEntrySize);
+
+        // We should now be at a NUL symbol (all fields are 0). We will check.
+        if ($found !== $expect) {
+            throw new \RuntimeException(sprintf(
+                'Import Data (.idata) section expected %d entries, however ' .
+                'a NUL section was not encountered, indicating there may be ' .
+                'more data.',
+                $symbolCount
+            ));
+        }
+
+        /**
+         * Now we loop through each import directory, parse the lookup table and
+         * merge in the new symbols.
+         */
+        foreach ($directories as $directory) {
+            $symbols = $this->parseImportDirectoryEntryLookupTable($directory);
+            $section->symbols = array_merge($section->symbols, $symbols);
+        }
+
+        $this->obj->sections[] = $section;
+    }
+
+    protected function parseDelayedLoadTable(): void {
+        if (! $this->obj->delayImportDescriptorSize) {
+            return;
+        }
+
+        throw new \Exception(sprintf(
+            'Delayed Load Table parsing has not been implemented. Dll "%s" ' .
+            'contains a delayed load import table. Please lodge a ticket.',
+            basename($this->objFile->filepath)
+        ));
+    }
+
+    protected function parseExportTable(): void {
+        if (! $this->obj->exportTableSize) {
+            return;
+        }
+
+        $edtOffset = $this->obj->translateRva($this->obj->exportTableRva);
+
+        $section = new Section;
+        $section->name = '.edata';
+        $section->virtualAddress = $this->obj->exportTableRva;
+        $section->virtualSize = $this->obj->exportTableSize;
+        $section->sizeOfRawData = $this->obj->exportTableSize;
+        $section->pointerToRawData = $edtOffset;
+
+        // Parse the Export Directory Table.
+        $edt = new \stdClass;
+        $edt->flags = $this->parseWord($edtOffset);
+        $edt->timeDateStamp = $this->parseWord($edtOffset);
+        $edt->majorVersion = $this->parseHalf($edtOffset);
+        $edt->minorVersion = $this->parseHalf($edtOffset);
+        $edt->nameRva = $this->parseWord($edtOffset);
+        $edt->ordinalBase = $this->parseWord($edtOffset);
+        $edt->addressTableEntries = $this->parseWord($edtOffset);
+        $edt->numberOfNamePointers = $this->parseWord($edtOffset);
+        $edt->exportAddressTableRva = $this->parseWord($edtOffset);
+        $edt->namePointerRva = $this->parseWord($edtOffset);
+        $edt->ordinalTableRva = $this->parseWord($edtOffset);
+
+        // Resolve the relative virtual addresses.
+        $edt->nameAddress = $this->obj->translateRva($edt->nameRva);
+        $edt->exportAddressTableAddress =
+            $this->obj->translateRva($edt->exportAddressTableRva);
+        $edt->namePointerAddress =
+            $this->obj->translateRva($edt->namePointerRva);
+        $edt->ordinalTableAddress =
+            $this->obj->translateRva($edt->ordinalTableRva);
+
+        for ($i = 0; $i < $edt->numberOfNamePointers; $i++) {
+            $symbol = $this->parseExportTableEntry($edt, $i);
+            $section->symbols[] = $symbol;
+        }
+
+        $this->obj->sections[] = $section;
+    }
+
+    protected function parseImportDirectoryEntry(int $offset) {
+        $entry = new ImportDirectoryEntry;
+
+        $entry->importLookupTableRva = $this->parseWord($offset);
+        $entry->timeDateStamp = $this->parseWord($offset);
+        $entry->forwarderChain = $this->parseWord($offset);
+        $entry->nameRva = $this->parseWord($offset);
+        $entry->importAddressTableRva = $this->parseWord($offset);
+
+        // Resolve DLL name
+        $offset = $this->obj->translateRva($entry->nameRva);
+        $entry->dllFilename = $this->parseString($offset);
+
+        return $entry;
+    }
+
+    protected function parseImportDirectoryEntryLookupTable(
+        ImportDirectoryEntry $directory
+    ): array {
+        $offset = 0;
+        $entrySize = $this->obj->is32Bit() ? 4 : 8;
+        $lookupTableOffset = $this->obj->translateRva($directory->importLookupTableRva);
+
+        /**
+         * @var ImportLookupTableEntry[]
+         */
+        $symbols = [];
+
+        for ($i = 0;; $i++) {
+            $offset = ($i * $entrySize) + $lookupTableOffset;
+            $symbol = $this->parseImportTableEntry($directory, $offset);
+
+            // We have reached the end of our lookup table.
+            if (is_null($symbol)) {
+                break;
+            }
+
+            $symbol->dllFilename = $directory->dllFilename;
+            $symbols[] = $symbol;
+        }
+
+        return $symbols;
+    }
+
+    protected function parseImportTableEntry(
+        ImportDirectoryEntry $directory,
+        int $offset
+    ): ?Symbol {
+        // Get the lookup table entry.
+        $lookupTable = $this->parseXWord($offset);
+
+        // We have reached the end of the import table.
+        if (0 === $lookupTable) {
+            return null;
+        }
+
+        $entry = new ImportLookupTableEntry;
+
+        /**
+         * The input lookup table is 32-bits on PE32 or 64-bits on PE32+. The
+         * most significant bit (31 or 63) denotes whether we are importing by
+         * an ordinal number, or a hint/name RVA.
+         */
+        $flagShift = ($this->obj->is32Bit() ? 31 : 63);
+        $entry->isOrdinal = (bool) ($lookupTable >> $flagShift) & 1;
+
+        if ($entry->isOrdinal) {
+            $entry->nameString = $this->parseHalf($lookupTable);
+        } else {
+            $offset = $this->obj->translateRva($lookupTable);
+            $hint = $this->parseHalf($offset);
+            $name = $this->parseNullTerminatedString($offset);
+            $entry->nameString = $name;
+        }
+
+        return $entry;
+    }
+
+    protected function parseExportTableEntry($entryDirectoryTable, $index) {
+        $entry = new ExportTableEntry;
+
+        /**
+         * Calculate the offsets for each the name and ordinal, based upon
+         * the $index parameter and the byte width of each the name and ordinal.
+         */
+        $nameOffset = $entryDirectoryTable->namePointerAddress + ($index * 4);
+        $ordOffset = $entryDirectoryTable->ordinalTableAddress + ($index * 2);
+
+        $entry->nameRva = $this->parseWord($nameOffset);
+        $entry->ordinal = $this->parseWord($ordOffset);
+
+        $eATA = $entryDirectoryTable->exportAddressTableAddress;
+        $exportedAddressRva = $eATA + $entry->ordinal;
+
+        $exportedNameAddress = $this->obj->translateRva($entry->nameRva);
+
+        $entry->nameString = $this->parseString($exportedNameAddress);
+        $entry->value = $this->parseWord($exportedAddressRva);
+
+        /**
+         * The exported address can be one of two formats. If the exported
+         * address is outside the Export section, the field is an Export RVA,
+         * referencing the RVA of a function. If the address is within the
+         * Export section, it is a forwarder RVA, which names a symbol within
+         * another DLL.
+         */
+        $startExportSection = $this->obj->exportTableRva;
+        $endExportSection = $startExportSection + $this->obj->exportTableSize;
+
+        if (
+            $exportedAddressRva >= $startExportSection &&
+            $exportedAddressRva <= $endExportSection
+        ) {
+            // We have a forwarder RVA.
+            $forwarderStringAddress = $this->obj->translateRva($exportedAddressRva);
+            $entry->isForwarder = true;
+            $entry->forwarderString = $this->parseString($forwarderStringAddress);
+        }
+
+        return $entry;
+    }
+
+    protected function parseCoffSymbol(int $offset): Symbol {
+        $symbol = new Symbol;
+
+        $symbol->shortName = $this->parseString($offset, 8);
+        $symbol->value = $this->parseWord($offset);
+        $symbol->sectionNumber = $this->parseHalf($offset);
+        $symbol->type = $this->parseHalf($offset);
+        $symbol->storageClass = ord($this->data[$offset]);
+        $symbol->numberOfAuxSymbols = ord($this->data[$offset+1]);
+
+        // We must test if the shortname is a reference to the string table.
+        $reference = unpack('vmask/vaddress', $symbol->shortName);
+
+        if ("\x0" === $reference['mask']) {
+            $stringOffset = $this->parseString($reference['address']);
+            $stringAddress = $this->obj->coffStringTableOffset + $stringOffset;
+            $symbol->name = $this->parseString($stringAddress);
+        } else {
+            $symbol->name = $symbol->shortName;
+        }
+
+        return $symbol;
+    }
+
+    protected function parseString(int &$offset, int $width = 0): string {
+        $string = $this->parseNullTerminatedString($offset, $width);
+
+        // Trim any NUL characters from the end of the string.
+        $string = rtrim($string, "\x0");
+
+        return $string;
+    }
+}

--- a/lib/PE/Section.php
+++ b/lib/PE/Section.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace PHPObjectSymbolResolver\PE;
+
+/**
+ * @see https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers
+ */
+class Section {
+    public int $offset;
+    /**
+     * An 8-byte, null-padded UTF-8 encoded string. If the string is exactly 8
+     * characters long, there is no terminating null. For longer names, this
+     * field contains a slash (/) that is followed by an ASCII representation
+     * of a decimal number that is an offset into the string table. Executable
+     * images do not use a string table and do not support section names longer
+     * than 8 characters. Long names in object files are truncated if they are
+     * emitted to an executable file.
+     */
+    public string $name;
+
+    /**
+     * The total size of the section when loaded into memory. If this value is
+     * greater than SizeOfRawData, the section is zero-padded. This field is
+     * valid only for executable images and should be set to zero for object
+     * files.
+     */
+    public int $virtualSize;
+
+    /**
+     * For executable images, the address of the first byte of the section
+     * relative to the image base when the section is loaded into memory. For
+     * object files, this field is the address of the first byte before
+     * relocation is applied; for simplicity, compilers should set this to zero.
+     * Otherwise, it is an arbitrary value that is subtracted from offsets
+     * during relocation.
+     */
+    public int $virtualAddress;
+
+    /**
+     * The size of the section (for object files) or the size of the initialized
+     * data on disk (for image files). For executable images, this must be a
+     * multiple of FileAlignment from the optional header. If this is less than
+     * VirtualSize, the remainder of the section is zero-filled. Because the
+     * SizeOfRawData field is rounded but the VirtualSize field is not, it is
+     * possible for SizeOfRawData to be greater than VirtualSize as well. When
+     * a section contains only uninitialized data, this field should be zero.
+     */
+    public int $sizeOfRawData;
+
+    /**
+     * The file pointer to the first page of the section within the COFF file.
+     * For executable images, this must be a multiple of FileAlignment from the
+     * optional header. For object files, the value should be aligned on a
+     * 4-byte boundary for best performance. When a section contains only
+     * uninitialized data, this field should be zero.
+     */
+    public int $pointerToRawData;
+
+    /**
+     * The file pointer to the beginning of relocation entries for the section.
+     * This is set to zero for executable images or if there are no relocations.
+     */
+    public int $pointerToRelocations;
+
+    /**
+     * The file pointer to the beginning of line-number entries for the section.
+     * This is set to zero if there are no COFF line numbers. This value should
+     * be zero for an image because COFF debugging information is deprecated.
+     */
+    public int $pointerToLineNumbers;
+
+    /**
+     * The number of relocation entries for the section. This is set to zero for
+     * executable images.
+     */
+    public int $numberOfRelocations;
+
+    /**
+     * The number of line-number entries for the section. This value should be
+     * zero for an image because COFF debugging information is deprecated.
+     */
+    public int $numberOfLineNumbers;
+
+    /**
+     * The flags that describe the characteristics of the section.
+     */
+    public int $characteristics;
+
+    /**
+     * Section Flags for the Characteristics member.
+     */
+    const IMAGE_SCN_TYPE_NO_PAD = 0x00000008;
+    const IMAGE_SCN_CNT_CODE = 0x00000020;
+    const IMAGE_SCN_CNT_INITIALIZED_DATA = 0x00000040;
+    const IMAGE_SCN_CNT_UNINITIALIZED_DATA = 0x00000080;
+    const IMAGE_SCN_LNK_OTHER = 0x00000100;
+    const IMAGE_SCN_LNK_INFO = 0x00000200;
+    const IMAGE_SCN_LNK_REMOVE = 0x00000800;
+    const IMAGE_SCN_LNK_COMDAT = 0x00001000;
+    const IMAGE_SCN_GPREL = 0x00008000;
+    const IMAGE_SCN_MEM_PURGEABLE = 0x00020000;
+    const IMAGE_SCN_MEM_16BIT = 0x00020000;
+    const IMAGE_SCN_MEM_LOCKED = 0x00040000;
+    const IMAGE_SCN_MEM_PRELOAD = 0x00080000;
+    const IMAGE_SCN_ALIGN_1BYTES = 0x00100000;
+    const IMAGE_SCN_ALIGN_2BYTES = 0x00200000;
+    const IMAGE_SCN_ALIGN_4BYTES = 0x00300000;
+    const IMAGE_SCN_ALIGN_8BYTES = 0x00400000;
+    const IMAGE_SCN_ALIGN_16BYTES = 0x00500000;
+    const IMAGE_SCN_ALIGN_32BYTES = 0x00600000;
+    const IMAGE_SCN_ALIGN_64BYTES = 0x00700000;
+    const IMAGE_SCN_ALIGN_128BYTES = 0x00800000;
+    const IMAGE_SCN_ALIGN_256BYTES = 0x00900000;
+    const IMAGE_SCN_ALIGN_512BYTES = 0x00A00000;
+    const IMAGE_SCN_ALIGN_1024BYTES = 0x00B00000;
+    const IMAGE_SCN_ALIGN_2048BYTES = 0x00C00000;
+    const IMAGE_SCN_ALIGN_4096BYTES = 0x00D00000;
+    const IMAGE_SCN_ALIGN_8192BYTES = 0x00E00000;
+    const IMAGE_SCN_LNK_NRELOC_OVFL = 0x01000000;
+    const IMAGE_SCN_MEM_DISCARDABLE = 0x02000000;
+    const IMAGE_SCN_MEM_NOT_CACHED = 0x04000000;
+    const IMAGE_SCN_MEM_NOT_PAGED = 0x08000000;
+    const IMAGE_SCN_MEM_SHARED = 0x10000000;
+    const IMAGE_SCN_MEM_EXECUTE = 0x20000000;
+    const IMAGE_SCN_MEM_READ = 0x40000000;
+    const IMAGE_SCN_MEM_WRITE = 0x80000000;
+
+    /**
+     * @var Symbol[]
+     */
+    public $symbols = [];
+}

--- a/lib/PE/Section.php
+++ b/lib/PE/Section.php
@@ -6,7 +6,6 @@ namespace PHPObjectSymbolResolver\PE;
  * @see https://learn.microsoft.com/en-us/windows/win32/debug/pe-format#section-table-section-headers
  */
 class Section {
-    public int $offset;
     /**
      * An 8-byte, null-padded UTF-8 encoded string. If the string is exactly 8
      * characters long, there is no terminating null. For longer names, this
@@ -16,7 +15,7 @@ class Section {
      * than 8 characters. Long names in object files are truncated if they are
      * emitted to an executable file.
      */
-    public string $name;
+    public string $nameString;
 
     /**
      * The total size of the section when loaded into memory. If this value is

--- a/lib/PE/Symbol.php
+++ b/lib/PE/Symbol.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace PHPObjectSymbolResolver\PE;
+
+class Symbol implements \PHPObjectSymbolResolver\Symbol {
+    public string $nameString;
+
+    /**
+     * This is unused.
+     */
+    public function isOther(int $other): bool {
+        return false;
+    }
+
+    /**
+     * At this point, we do not scan for local symbols.
+     */
+	public function isLocal(): bool {
+        return false;
+    }
+
+    /**
+     * At this point, we only scan for global symbols.
+     */
+	public function isGlobal(): bool {
+        return true;
+    }
+
+    /**
+     * Symbols are only weak if they are delay-loaded.
+     */
+	public function isWeak(): bool {
+        return false;
+    }
+}

--- a/lib/Parser.php
+++ b/lib/Parser.php
@@ -23,9 +23,16 @@ abstract class Parser {
 		} elseif ($magic === FatBinary::MAGIC) {
             $fatBinary = new FatBinary($file);
             return (new MachO\Parser)->parse($file, $fatBinary->getOffsetForLocalArch());
-        }
+		} elseif (PE\Parser::isPortableExecutable($file)) {
+			return (new PE\Parser)->parse($file);
+        } elseif (substr($magic, 0, 2) === PE\Parser::HEADER) {
+			throw new \LogicException(
+				"File is MS-DOS compatible but is not in the PE format. " .
+				"MS-DOS executables are not supported."
+			);
+		}
 
-		throw new \LogicException("File is neither in ELF nor Mach-O format");
+		throw new \LogicException("File is neither in ELF, Mach-O nor PE format");
 	}
 
 	protected function parseAddr(int &$offset): string {


### PR DESCRIPTION
This pull request adds functionality for Windows Portable Executable files.
The Portable Executable format does not support storing symbols within the executable file, so this really only works for named imports or exports.